### PR TITLE
Upgrade Maven Dependency Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,4 +12,16 @@
     <module>java11</module>
     <module>java16</module>
   </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
Since the Dockerfiles contain `mvn test dependency:go-offline --fail-at-end`, it would be good to use the latest version of the Maven Dependency Plugin. In that version (3.1.2), a lot of bugs have been fixed in the `go-offline` goal - compared to the 2.8 that comes with Maven 3.x by default.